### PR TITLE
Moved heading write until after read

### DIFF
--- a/signal-compiler.c
+++ b/signal-compiler.c
@@ -45,8 +45,6 @@ int main(int ac, char *av[]) {
   if (pptr < 0)
     syslog(LOG_USER, "failed  to open %s\n", av[2]);
 
-
-
   uint8_t sbuf[PGM_W] = {0};
   uint8_t pgm_buf[PGM_W][PGM_H] = {0};
 

--- a/signal-compiler.c
+++ b/signal-compiler.c
@@ -45,8 +45,7 @@ int main(int ac, char *av[]) {
   if (pptr < 0)
     syslog(LOG_USER, "failed  to open %s\n", av[2]);
 
-  const char *pgm_init = "P5 " STR(PGM_W) " " STR(PGM_H) " " STR(PGM_DEPTH) " ";
-  write(pptr, pgm_init, strlen(pgm_init));
+
 
   uint8_t sbuf[PGM_W] = {0};
   uint8_t pgm_buf[PGM_W][PGM_H] = {0};
@@ -79,6 +78,8 @@ int main(int ac, char *av[]) {
     }
   }
 
+  const char *pgm_init = "P5 " STR(PGM_W) " " STR(PGM_H) " " STR(PGM_DEPTH) " ";
+  write(pptr, pgm_init, strlen(pgm_init));
   // - write(pptr, pgm_buf, PGM_H * PGM_W)
   // - write(pptr, pgm_buf[ii], PGM_H)
   // - write(pptr, &pgm_buf[ii][jj], 1)   <-- use this one (byte-order reasons)


### PR DESCRIPTION
Possibly causing this issue, but seems unlikely given further analysis:

Steps to reproduce: 
- Turn on
- Click wacom button 1
- wait
- Click wacom button 1 again
```
Jan  1 00:00:31 buildroot user.info trigger-data: (49,)
Jan  1 00:00:31 buildroot user.info trigger-data: writing to oscope
Jan  1 00:00:33 buildroot user.info trigger-data: reading from oscope
Jan  1 00:00:33 buildroot user.info trigger-data: (0, 131, 129, 128, 129, 131, 129, 128, 125, 129, 133, 133, 133, 128, 132, 133, 133, 128, 125, 128, 129, 131, 128, 127, 130, 132, 130, 128, 127, 131, 133, 131, 132, 129, 135, 133, 130, 128, 126, 131, 129, 130, 125, 126, 13
Jan  1 00:00:33 buildroot user.info trigger-data: wrote 480 bytes
Jan  1 00:00:33 buildroot user.info sigproc: read 480 bytes
Jan  1 00:00:33 buildroot user.info sigproc: writing
Jan  1 00:00:33 buildroot user.info sigproc: wrote 480 bytes
Jan  1 00:00:33 buildroot user.info signal-compiler: read signal 480
Jan  1 00:00:33 buildroot user.info trigger-data: reading
Jan  1 00:00:33 buildroot user.info trigger-data: (10,)
Jan  1 00:00:33 buildroot user.info trigger-data: reading
Jan  1 00:00:33 buildroot user.info trigger-data: (48,)
Jan  1 00:00:34 buildroot user.info trigger-data: reading
Jan  1 00:00:34 buildroot user.info trigger-data: (10,)
Jan  1 00:00:34 buildroot user.info trigger-data: reading
Jan  1 00:00:34 buildroot user.info sigproc: starting
Jan  1 00:00:34 buildroot user.info sigproc: reading
Jan  1 00:00:35 buildroot user.info signal-compiler: wrote PGM size 144000
Jan  1 00:01:04 buildroot user.info trigger-data: (49,)
Jan  1 00:01:04 buildroot user.info trigger-data: writing to oscope
Jan  1 00:01:07 buildroot user.info trigger-data: reading from oscope
Jan  1 00:01:07 buildroot user.info trigger-data: (130, 97, 103, 105, 104, 99, 101, 101, 105, 103, 94, 98, 100, 103, 101, 98, 101, 104, 106, 103, 99, 100, 104, 103, 103, 100, 101, 101, 104, 102, 95, 99, 99, 101, 101, 99, 99, 105, 107, 102, 100, 103, 104, 103, 102, 97, 10
Jan  1 00:01:07 buildroot user.info trigger-data: wrote 480 bytes
Jan  1 00:01:07 buildroot user.info sigproc: read 480 bytes
Jan  1 00:01:07 buildroot user.info sigproc: writing
Jan  1 00:01:07 buildroot user.info sigproc: wrote 480 bytes
Jan  1 00:01:07 buildroot user.info signal-compiler: read signal 480
Jan  1 00:01:07 buildroot user.info trigger-data: reading
Jan  1 00:01:07 buildroot user.info trigger-data: (10,)
Jan  1 00:01:07 buildroot user.info trigger-data: reading
Jan  1 00:01:07 buildroot user.info trigger-data: (48,)
Jan  1 00:01:07 buildroot user.info pnt-lut: read PGM 144015
Jan  1 00:01:08 buildroot user.info trigger-data: reading
Jan  1 00:01:08 buildroot user.info trigger-data: (10,)
Jan  1 00:01:08 buildroot user.info trigger-data: reading
Jan  1 00:01:08 buildroot user.info sigproc: starting
Jan  1 00:01:08 buildroot user.info sigproc: reading
Jan  1 00:01:09 buildroot user.info signal-compiler: wrote PGM size 144000
```
